### PR TITLE
Extend TUF API to register signature provider for external keys

### DIFF
--- a/tuf/exceptions.py
+++ b/tuf/exceptions.py
@@ -22,17 +22,16 @@
   there is a good reason not to, and provide that reason in those cases.
 """
 
+
 # Help with Python 3 compatibility, where the print statement is a function, an
 # implicit relative import is invalid, and the '/' operator performs true
 # division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
 
 import six
 
-import logging
 logger = logging.getLogger('tuf.exceptions')
 
 
@@ -257,3 +256,7 @@ class URLParsingError(Error):
 class InvalidConfigurationError(Error):
   """If a configuration object does not match the expected format."""
 
+
+class SignatureProviderAlreadyExistsError(Error):
+  """Indicate that a signature provider for keyid already exists and cannot be
+  added."""


### PR DESCRIPTION
This PR extends TUF API in a way that it allows passing signature provider if private key cannot be loaded (write-only devices such as YubiKey does not allow exporting private keys). During process of signing and writing metadata files, TUF will call signature provider function for registered _keyid_.

Usage:

```python
...

# Load signing key from a file (still can be used)
repository.targets.load_signing_key( targets_private_key )

def signature_provider(data):
    """Should return signature..."""

# In case private key cannot be loaded from a file
repository.targets.add_external_signature_provider(external_public_targets_key, signature_provider)

...
```

or if we need _keyid_ inside our `signature_provider` callabe:

```python
def signature_provider(keyid, data):
    """Should return signature..."""

repository.targets.add_external_signature_provider(external_public_targets_key, partial(signature_provider, public_targets_key['keyid']))
```

This allows us to read a signature from a file, if signature is generated on another PC (remote YubiKeys).