### PR TITLE
Use oll-securesystemslib with new signature scheme

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
   - set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
   - python -m pip install -U pip
   - pip install -e .
-  - pip install securesystemslib[crypto,pynacl]
+  - pip install oll-securesystemslib[crypto,pynacl]
 
 build: false
 

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -1,4 +1,4 @@
-securesystemslib[crypto,pynacl]==0.11.3
+oll-securesystemslib[crypto,pynacl]==0.11.3.dev4
 six
 iso8601
 coverage

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -1,4 +1,4 @@
-oll-securesystemslib[crypto,pynacl]==0.11.3.dev4
+oll-securesystemslib[crypto,pynacl]==0.11.3.dev5
 six
 iso8601
 coverage

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -42,7 +42,7 @@ pylint==1.9.3 ; python_version < "3.0" # pyup: ignore
 pynacl==1.3.0
 pyyaml==4.2b1
 requests==2.21.0
-oll-securesystemslib[crypto,pynacl]==0.11.3.dev4
+oll-securesystemslib[crypto,pynacl]==0.11.3.dev5
 singledispatch==3.4.0.3
 six==1.12.0
 smmap2==2.0.5

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -42,7 +42,7 @@ pylint==1.9.3 ; python_version < "3.0" # pyup: ignore
 pynacl==1.3.0
 pyyaml==4.2b1
 requests==2.21.0
-securesystemslib[crypto,pynacl]==0.11.3
+oll-securesystemslib[crypto,pynacl]==0.11.3.dev4
 singledispatch==3.4.0.3
 six==1.12.0
 smmap2==2.0.5

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 # requirements.in for pip-compile.
 
-securesystemslib
+oll-securesystemslib
 cryptography
 colorama
 pynacl

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,26 +83,17 @@ cryptography==2.4.2 \
     --hash=sha256:af12dfc9874ac27ebe57fc28c8df0e8afa11f2a1025566476b0d50cdb8884f70 \
     --hash=sha256:b4fc04326b2d259ddd59ed8ea20405d2e695486ab4c5e1e49b025c484845206e \
     --hash=sha256:da5b5dda4aa0d5e2b758cc8dfc67f8d4212e88ea9caad5f61ba132f948bab859
-enum34==1.1.6 \
-    --hash=sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850 \
-    --hash=sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a \
-    --hash=sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79 \
-    --hash=sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1 \
-    ; python_version < "3.0"
-    # via cryptography (in Python2)
 idna==2.8 \
     --hash=sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407 \
     --hash=sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c \
     # via cryptography, requests
-ipaddress==1.0.22 \
-    --hash=sha256:64b28eec5e78e7510698f6d4da08800a5c575caa4a286c93d651c5d3ff7b6794 \
-    --hash=sha256:b146c751ea45cad6188dd6cf2d9b757f6f4f8d6ffb96a023e6f2e26eea02a72c \
-    ; python_version < "3.0" # pyup: ignore
-    # via cryptography (in Python2)
 iso8601==0.1.12 \
     --hash=sha256:210e0134677cc0d02f6028087fee1df1e1d76d372ee1db0bf30bf66c5c1c89a3 \
     --hash=sha256:49c4b20e1f38aa5cf109ddcd39647ac419f928512c869dc01d5c7098eddede82 \
     --hash=sha256:bbbae5fb4a7abfe71d4688fd64bff70b91bbd74ef6a99d964bab18f7fdf286dd
+oll-securesystemslib==0.11.3.dev4 \
+    --hash=sha256:19310d6211d0a288ec06dd82f322486694576cc17e7918c80d7bf5d86ce11798 \
+    --hash=sha256:87faf8d90034cbd192d39b3b48a5719de33009a673b38b0163c55276113bef76
 pycparser==2.19 \
     --hash=sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3 \
     # via cffi
@@ -129,9 +120,6 @@ pynacl==1.3.0 \
 requests==2.21.0 \
     --hash=sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e \
     --hash=sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b
-securesystemslib==0.11.3 \
-    --hash=sha256:368ef6f6cc40d3636e271485c7adb21c53c22200bab44a2fe8af62886a01c3d5 \
-    --hash=sha256:cbd1f7f1af2f2921be33b9fd17384705f5f4147d3a8b5d95b33ec3ce2213f176
 six==1.12.0 \
     --hash=sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c \
     --hash=sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(
         'iso8601>=0.1.12',
         'requests>=2.19.1',
         'six>=1.11.0',
-        'oll-securesystemslib==0.11.3.dev4'
+        'oll-securesystemslib==0.11.3.dev5'
     ],
     packages=find_packages(exclude=['tests']),
     scripts=[

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ with open('README.md') as file_object:
 
 setup(
     name='oll-tuf',
-    version='0.11.2.dev6',  # If updating version, also update it in tuf/__init__.py
+    version='0.11.2.dev7',  # If updating version, also update it in tuf/__init__.py
     description='Open Law Library fork of TUF',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(
         'iso8601>=0.1.12',
         'requests>=2.19.1',
         'six>=1.11.0',
-        'securesystemslib==0.11.3'
+        'oll-securesystemslib==0.11.3.dev4'
     ],
     packages=find_packages(exclude=['tests']),
     scripts=[

--- a/tuf/__init__.py
+++ b/tuf/__init__.py
@@ -2,4 +2,4 @@
 # setup.py has it hard-coded separately.
 # Currently, when the version is changed, it must be set in both locations.
 # TODO: Single-source the version number.
-__version__ = "0.11.2.dev6"
+__version__ = "0.11.2.dev7"

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1711,7 +1711,7 @@ def sign_metadata(metadata_object, keyids, filename, repository_name):
           logger.warning('Unable to create signature for keyid: ' + repr(keyid))
 
       elif signature_provider:
-        signature = signature_provider(signed)
+        signature = signature_provider(key, signed) # Key without private part
         signable['signatures'].append(signature)
 
       else:


### PR DESCRIPTION
Use `oll-securesystemslib` to be able to provide `rsa-pkcs1v15-sha256` signature scheme.