### PR TITLE
Update securesystemslib version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ with open('README.md') as file_object:
 
 setup(
     name='oll-tuf',
-    version='0.11.2.dev7',  # If updating version, also update it in tuf/__init__.py
+    version='0.11.2.dev8',  # If updating version, also update it in tuf/__init__.py
     description='Open Law Library fork of TUF',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -112,7 +112,7 @@ setup(
         'iso8601>=0.1.12',
         'requests>=2.19.1',
         'six>=1.11.0',
-        'oll-securesystemslib==0.11.3.dev5'
+        'oll-securesystemslib==0.11.3.dev6'
     ],
     packages=find_packages(exclude=['tests']),
     scripts=[

--- a/tuf/__init__.py
+++ b/tuf/__init__.py
@@ -2,4 +2,4 @@
 # setup.py has it hard-coded separately.
 # Currently, when the version is changed, it must be set in both locations.
 # TODO: Single-source the version number.
-__version__ = "0.11.2.dev7"
+__version__ = "0.11.2.dev8"


### PR DESCRIPTION
Update _securesystemslib_ which includes following fix: https://github.com/openlawlibrary/securesystemslib/pull/5.