### PR TITLE
fix: include `root.json` in snapshot metadata, release 0.20.0.dev2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+
+setup()

--- a/tuf/__init__.py
+++ b/tuf/__init__.py
@@ -2,7 +2,7 @@
 # setup.cfg has it hard-coded separately.
 # Currently, when the version is changed, it must be set in both locations.
 # TODO: Single-source the version number.
-__version__ = "0.20.0.dev1"
+__version__ = "0.20.0.dev2"
 
 # This reference implementation produces metadata intended to conform to
 # version 1.0.0 of the TUF specification, and is expected to consume metadata

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1774,11 +1774,16 @@ def generate_snapshot_metadata(metadata_directory, version, expiration_date,
   length, hashes = _get_hashes_and_length_if_needed(use_length, use_hashes,
       os.path.join(metadata_directory, TARGETS_FILENAME), storage_backend)
 
+  root_role = ROOT_FILENAME[:-len(METADATA_EXTENSION)]
   targets_role = TARGETS_FILENAME[:-len(METADATA_EXTENSION)]
 
+  root_file_version = get_metadata_versioninfo(root_role,
+      repository_name)
   targets_file_version = get_metadata_versioninfo(targets_role,
       repository_name)
 
+  fileinfodict[ROOT_FILENAME] = formats.make_metadata_fileinfo(
+      root_file_version['version'], length, hashes)
   # Make file info dictionary with make_metadata_fileinfo because
   # in the tuf spec length and hashes are optional for all
   # METAFILES in snapshot.json including the top-level targets file.


### PR DESCRIPTION
TUF revised it's specification and removed root from snapshot. Implementation and mention is in [this
issue](https://github.com/theupdateframework/python-tuf/issues/933)

This usually wouldn't be an issue for any application using TUF. However, TAF updater validates metadata *across history*. Since our snapshots included root.json, this means that in git history there will surely exist `snapshot.json` whichs includes `root`. Current TUF excludes `root.json` from snapshot and at time of writing, the latest TUF updater checks for replay attacks by comparing existing `snapshot.json` with the newly downloaded `snapshot.json`. If any field in the metadata got changed or missing (like root is missing), snapshot is considered invalid. This will cause updater to raise an error. Please see [this code](https://github.com/theupdateframework/python-tuf/blob/7ada2af384442f1c3775a4bcbd9f33270c1c8fa0/tuf/ngclient/_internal/trusted_metadata_set.py#L321-L328)

To mitigate, we fix the `repository_lib` function to behave as old TUF implementation was behaving. Since the metadata API is being deprecated, I don't think there's a real reason not to revert back to previous metadata state.
However, this will have to get addressed once we transition to new TUF metadata API

See #https://github.com/openlawlibrary/taf/issues/280


- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


